### PR TITLE
ci: expand matrix coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,9 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
-      matrix:
-        node-version: [18, 20]
+      matrix:\n        os: [ubuntu-latest, windows-latest]\n        node-version: [18, 20]
     defaults:
       run:
         working-directory: app


### PR DESCRIPTION
## Summary
- add ubuntu/windows coverage for Node 18 and 20
- continue caching npm installs per job

## Testing
- not applicable